### PR TITLE
Feature/v3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Zalo PC: `.app-lock__main__input`
 
+### Changed
+- `.chat-input__content.highlight`
+
 ## v3.5
 
 > 2022-03-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.6
+
+> 2022-03-08
+
+### Fixed
+- Zalo PC: `.app-lock__main__input`
+
 ## v3.5
 
 > 2022-03-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Zalo PC: `.app-lock__main__input`
+- `.tipv2 .tip-close-button`
 
 ### Changed
 - `.chat-input__content.highlight`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ All notable changes to this project will be documented in this file.
 
 > 2022-03-08
 
-### Fixed
-- Zalo PC: `.app-lock__main__input`
-- `.tipv2 .tip-close-button`
+### Added
+- Browser Extension: Allows users to Enable/Disable notifications when ZaDark updates
 
 ### Changed
 - `.chat-input__content.highlight`
+
+### Fixed
+- Zalo PC: `.app-lock__main__input`
+- `.tipv2 .tip-close-button`
 
 ## v3.5
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ yarn dist
     - [x] Welcome page
     - [x] Changelog page
     - [x] Sync theme with system
+    - [x] Allows users to Enable/Disable notifications when ZaDark updates
+    - [ ] Custom Fonts
     - [ ] More themes
 
 ### For Zalo PC

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "za-dark",
   "description": "Best Dark Theme for Zalo",
-  "version": "3.5",
+  "version": "3.6",
   "repository": "git@github.com:ncdai3651408/za-dark.git",
   "author": "Dai Nguyen <ncdai3651408@gmail.com>",
   "license": "MIT",

--- a/src/browser-ext/changelog.html
+++ b/src/browser-ext/changelog.html
@@ -44,7 +44,7 @@
   </header>
 
   <main class="p-4">
-    <h1 class="text-2xl mb-4 font-semibold">What's new in ZaDark <span id="ext-version2"></span></h1>
+    <h1 class="text-2xl mb-4 font-semibold">What's new in ZaDark <span id="ext-version2"></span>?</h1>
 
     <div class="panel">
       <div class="panel-body">
@@ -55,12 +55,26 @@
         </p>
 
         <ul>
+          <li>Added: Allows users to Enable/Disable notifications when ZaDark updates (Browser Extension)</li>
+          <li>Changed: <code>.chat-input__content.highlight</code></li>
           <li>Fixed: <code>.app-lock__main__input</code></li>
           <li>Fixed: <code>.tipv2 .tip-close-button</code></li>
-          <li>Changed: <code>.chat-input__content.highlight</code></li>
         </ul>
 
         <p>Thank you for using!</p>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-body">
+        <div class="flex items-center">
+          <label class="mr-4 cursor-pointer" for="checkbox-receive-update-noti">Receive notifications when ZaDark updates</label>
+
+          <label class="form-switch">
+            <input type="checkbox" id="checkbox-receive-update-noti">
+            <span class="form-switch-slider"></span>
+          </label>
+        </div>
       </div>
     </div>
   </main>

--- a/src/browser-ext/changelog.html
+++ b/src/browser-ext/changelog.html
@@ -56,6 +56,7 @@
 
         <ul>
           <li>Fixed: <code>.app-lock__main__input</code></li>
+          <li>Fixed: <code>.tipv2 .tip-close-button</code></li>
           <li>Changed: <code>.chat-input__content.highlight</code></li>
         </ul>
 

--- a/src/browser-ext/changelog.html
+++ b/src/browser-ext/changelog.html
@@ -56,6 +56,7 @@
 
         <ul>
           <li>Fixed: <code>.app-lock__main__input</code></li>
+          <li>Changed: <code>.chat-input__content.highlight</code></li>
         </ul>
 
         <p>Thank you for using!</p>

--- a/src/browser-ext/changelog.html
+++ b/src/browser-ext/changelog.html
@@ -55,7 +55,7 @@
         </p>
 
         <ul>
-          <li>Fixed: <code>.toast</code></li>
+          <li>Fixed: <code>.app-lock__main__input</code></li>
         </ul>
 
         <p>Thank you for using!</p>

--- a/src/browser-ext/js/changelog.js
+++ b/src/browser-ext/js/changelog.js
@@ -12,3 +12,16 @@ $('#ext-links-home').on('click', () => {
 })
 
 window.zadark.utils.refreshPageTheme()
+
+// Receive update notifications
+
+const checkboxReceiveUpdateNotiElName = '#checkbox-receive-update-noti'
+
+window.zadark.browser.getExtensionSettings().then(({ isReceiveUpdateNoti }) => {
+  $(checkboxReceiveUpdateNotiElName).prop('checked', isReceiveUpdateNoti)
+})
+
+$(checkboxReceiveUpdateNotiElName).on('change', () => {
+  const isReceiveUpdateNoti = $(checkboxReceiveUpdateNotiElName).is(':checked')
+  window.zadark.browser.saveExtensionSettings({ isReceiveUpdateNoti })
+})

--- a/src/browser-ext/js/execute-script.js
+++ b/src/browser-ext/js/execute-script.js
@@ -4,4 +4,8 @@
   Made by NCDAi Studio
 */
 
-window.zadark.utils.refreshPageTheme()
+if (window.zadark) {
+  window.zadark.utils.refreshPageTheme()
+} else {
+  window.location.reload()
+}

--- a/src/browser-ext/scss/core.scss
+++ b/src/browser-ext/scss/core.scss
@@ -201,6 +201,9 @@ ul {
 .mr-2 {
   margin-right: 8px;
 }
+.mr-4 {
+  margin-right: 16px;
+}
 
 .mb-2 {
   margin-bottom: 8px;
@@ -227,6 +230,10 @@ ul {
 
 .text-zadark {
   font-family: "Bubblegum Sans", cursive;
+}
+
+.cursor-pointer {
+  cursor: pointer;
 }
 
 // END: Utils
@@ -376,6 +383,56 @@ header.main-header {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+}
+
+.form-switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+
+  input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  &-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--grey-base);
+    -webkit-transition: 0.25s;
+    transition: 0.25s;
+
+    border-radius: 50rem;
+
+    &:before {
+      position: absolute;
+      content: "";
+      height: 20px;
+      width: 20px;
+      left: 2px;
+      bottom: 2px;
+      background-color: white;
+      -webkit-transition: 0.25s;
+      transition: 0.25s;
+      border-radius: 50rem;
+    }
+  }
+
+  input:checked + .form-switch-slider {
+    background-color: #3989ff;
+  }
+
+  input:checked + .form-switch-slider:before {
+    -webkit-transform: translateX(24px);
+    -ms-transform: translateX(24px);
+    transform: translateX(24px);
+  }
 }
 
 .panel {

--- a/src/browser-ext/vendor/chrome/background.js
+++ b/src/browser-ext/vendor/chrome/background.js
@@ -10,6 +10,10 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 
   if (details.reason === 'update') {
-    chrome.tabs.create({ url: 'changelog.html' })
+    chrome.storage.sync.get({ isReceiveUpdateNoti: true }, ({ isReceiveUpdateNoti }) => {
+      if (isReceiveUpdateNoti) {
+        chrome.tabs.create({ url: 'changelog.html' })
+      }
+    })
   }
 })

--- a/src/browser-ext/vendor/chrome/browser.js
+++ b/src/browser-ext/vendor/chrome/browser.js
@@ -23,7 +23,8 @@
         chrome.storage.sync.get({
           themeMode: 'single',
           userTheme: 'dark_dimmed',
-          darkTheme: 'dark_dimmed'
+          darkTheme: 'dark_dimmed',
+          isReceiveUpdateNoti: true
         }, (items) => {
           resolve(items)
         })

--- a/src/browser-ext/vendor/chrome/manifest.json
+++ b/src/browser-ext/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Best Dark Theme for Zalo",
-  "version": "3.5",
+  "version": "3.6",
   "description": "The best dark theme for your Zalo.",
   "author": "NCDAi Studio",
   "homepage_url": "https://github.com/ncdai3651408/za-dark",

--- a/src/browser-ext/vendor/firefox/background.js
+++ b/src/browser-ext/vendor/firefox/background.js
@@ -10,6 +10,10 @@ browser.runtime.onInstalled.addListener((details) => {
   }
 
   if (details.reason === 'update') {
-    browser.tabs.create({ url: 'changelog.html' })
+    browser.storage.sync.get({ isReceiveUpdateNoti: true }, ({ isReceiveUpdateNoti }) => {
+      if (isReceiveUpdateNoti) {
+        browser.tabs.create({ url: 'changelog.html' })
+      }
+    })
   }
 })

--- a/src/browser-ext/vendor/firefox/browser.js
+++ b/src/browser-ext/vendor/firefox/browser.js
@@ -23,7 +23,8 @@
         browser.storage.sync.get({
           themeMode: 'single',
           userTheme: 'dark_dimmed',
-          darkTheme: 'dark_dimmed'
+          darkTheme: 'dark_dimmed',
+          isReceiveUpdateNoti: true
         }, (items) => {
           resolve(items)
         })

--- a/src/browser-ext/vendor/firefox/manifest.json
+++ b/src/browser-ext/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Best Dark Theme for Zalo",
-  "version": "3.5",
+  "version": "3.6",
   "description": "The best dark theme for your Zalo.",
   "author": "NCDAi Studio",
   "homepage_url": "https://github.com/ncdai3651408/za-dark",

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "za-dark-pc",
-  "version": "3.5",
+  "version": "3.6",
   "main": "index.js",
   "author": "Dai Nguyen <ncdai3651408@gmail.com>",
   "license": "MIT"

--- a/src/scss/za-dark.scss
+++ b/src/scss/za-dark.scss
@@ -387,7 +387,8 @@ html[data-theme-mode="dark"] {
     }
 
     .chat-input__content.highlight {
-      border-color: var(--neutral-500);
+      // border-color: var(--neutral-500);
+      border-color: #0068ff;
     }
 
     #ztoolbar div[icon="outline-za-screenshot"] {

--- a/src/scss/za-dark.scss
+++ b/src/scss/za-dark.scss
@@ -856,6 +856,32 @@ html[data-theme-mode="dark"] {
       box-shadow: 4px 4px 12px var(--black-500);
       padding: 16px 24px;
     }
+
+    // App Lock
+
+    .app-lock__main__input {
+      display: flex;
+      align-items: center;
+
+      input {
+        height: 40px;
+        padding: 0px 16px;
+        border-right: 0;
+        color: var(--neutral-base);
+      }
+
+      a {
+        height: 40px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0px 16px;
+
+        border: 1px solid var(--blue-300);
+        background: var(--gradient-blue);
+        color: var(--neutral-300);
+      }
+    }
   }
 }
 

--- a/src/scss/za-dark.scss
+++ b/src/scss/za-dark.scss
@@ -594,6 +594,9 @@ html[data-theme-mode="dark"] {
     .tipv2-content {
       color: var(--neutral-300);
     }
+    .tipv2 .tip-close-button {
+      color: var(--neutral-300);
+    }
 
     // Photo Quality HD
     .qu-ba {


### PR DESCRIPTION
## v3.6

> 2022-03-08

### Added
- Browser Extension: Allows users to Enable/Disable notifications when ZaDark updates

### Changed
- `.chat-input__content.highlight`

### Fixed
- Zalo PC: `.app-lock__main__input`
- `.tipv2 .tip-close-button`
