### PR TITLE
Fixed: Settings, Media Store Preview and Business Label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## PC v4.9 & Browser v5.4
+### Fixed
+- `.setting-menu` : Sửa lỗi chữ "Resource management" xuống dòng.
+- `.cb-info-file-item__actions-container` : Sửa lỗi màu nền sai khi rê chuột vào File (Media Store Preview).
+- `.chat-info-link__action` : Sửa lỗi mất màu nền khi rê chuột vào Link (Media Store Preview).
+- `.media-store-preview-item > .image-menu-container` : Sửa lỗi màu nền sai khi rê chuột vào Photo/Video (Media Store Preview).
+- `.z-business-label` : Sửa lỗi nhãn "Business" quá to không đẹp.
+
 ## PC v4.8 & Browser v5.3
 ### Fixed
 - Chat Onboard : `.slideshow__page__image` `.slideshow__page__text__title` `.slideshow__bottom`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "4.11",
+  "version": "4.12",
   "repository": "git@github.com:ncdai3651408/za-dark.git",
   "author": "Dai Nguyen <ncdai3651408@gmail.com>",
   "license": "MIT",

--- a/src/browser-ext/changelog.html
+++ b/src/browser-ext/changelog.html
@@ -45,7 +45,11 @@
         </p>
 
         <ul>
-          <li>Chat Onboard : <code>.slideshow__page__image</code> <code>.slideshow__page__text__title</code> <code>.slideshow__bottom</code></li>
+          <li><code>.setting-menu</code> : Sửa lỗi chữ "Resource management" xuống dòng.</li>
+          <li><code>.cb-info-file-item__actions-container</code> : Sửa lỗi màu nền sai khi rê chuột vào file (Media Store Preview).</li>
+          <li><code>.chat-info-link__action</code> : Sửa lỗi mất màu nền khi rê chuột vào link (Media Store Preview).</li>
+          <li><code>.media-store-preview-item > .image-menu-container</code> : Sửa lỗi màu nền sai khi rê chuột vào photo/video (Media Store Preview).</li>
+          <li><code>.z-business-label</code> : Sửa lỗi nhãn "Business" quá to không đẹp.</li>
         </ul>
 
         <p>Cảm ơn bạn đã tin tưởng sử dụng ZaDark!</p>

--- a/src/browser-ext/vendor/chrome/manifest.json
+++ b/src/browser-ext/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "5.3",
+  "version": "5.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/browser-ext/vendor/edge/manifest.json
+++ b/src/browser-ext/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "5.3",
+  "version": "5.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/browser-ext/vendor/firefox/manifest.json
+++ b/src/browser-ext/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "4.8",
+  "version": "4.9",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/browser-ext/vendor/opera/manifest.json
+++ b/src/browser-ext/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "5.3",
+  "version": "5.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/browser-ext/vendor/safari/ZaDark.xcodeproj/project.pbxproj
+++ b/src/browser-ext/vendor/safari/ZaDark.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1654875747;
+				CURRENT_PROJECT_VERSION = 1657621839;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -502,7 +502,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -521,7 +521,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1654875747;
+				CURRENT_PROJECT_VERSION = 1657621839;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1654875747;
+				CURRENT_PROJECT_VERSION = 1657621839;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -571,7 +571,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -594,7 +594,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1654875747;
+				CURRENT_PROJECT_VERSION = 1657621839;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -609,7 +609,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 5.3;
+				MARKETING_VERSION = 5.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/src/browser-ext/vendor/safari/manifest.json
+++ b/src/browser-ext/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "5.3",
+  "version": "5.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -481,14 +481,6 @@ html[data-theme-mode="dark"] {
       }
     }
 
-    #info-links-container {
-      .library-media {
-        > div {
-          background: transparent !important;
-        }
-      }
-    }
-
     #group-creator .create-group__item__link-icon {
       color: #fff;
     }
@@ -1032,6 +1024,25 @@ html[data-theme-mode="dark"] {
         margin-top: 50px;
       }
     }
+
+    .cb-info-file-item__actions-container {
+      background: var(--white-base);
+      box-shadow: 0 1px 10px var(--white-base);
+    }
+
+    .chat-info-link__action {
+      background: var(--white-base);
+      box-shadow: 0 1px 10px var(--white-base);
+    }
+
+    .media-store-preview-item > .image-menu-container {
+      background: var(--white-base) !important;
+      box-shadow: 0 1px 10px var(--white-base);
+
+      > div {
+        background: transparent !important;
+      }
+    }
   }
 }
 
@@ -1051,5 +1062,15 @@ body.zadark {
     #ztoolbar div[icon="outline-za-screenshot"] {
       display: none;
     }
+  }
+
+  .setting-menu {
+    width: 232px;
+  }
+
+  .z-business-label {
+    padding: 0 8px;
+    line-height: 18px;
+    font-size: 10px;
   }
 }

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "4.8",
+  "version": "4.9",
   "main": "index.js",
   "repository": "git@github.com:ncdai3651408/za-dark.git",
   "author": "Dai Nguyen <ncdai3651408@gmail.com>",


### PR DESCRIPTION
## PC v4.9 & Browser v5.4
### Fixed
- `.setting-menu` : Sửa lỗi chữ "Resource management" xuống dòng.
- `.cb-info-file-item__actions-container` : Sửa lỗi màu nền sai khi rê chuột vào File (Media Store Preview).
- `.chat-info-link__action` : Sửa lỗi mất màu nền khi rê chuột vào Link (Media Store Preview).
- `.media-store-preview-item > .image-menu-container` : Sửa lỗi màu nền sai khi rê chuột vào Photo/Video (Media Store Preview).
- `.z-business-label` : Sửa lỗi nhãn "Business" quá to không đẹp.