### PR TITLE
Feature/v22.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 ## ZaDark v22.9.6
 > PC 5.5 && Web v6.5
 
+### Changed
+- `.card--undo` : Bỏ hiệu ứng mờ cho tin nhắn được thu hồi
+- `:selection` : Cập nhật màu nền khi tô khối chữ
+- `colors` : Thay đổi màu sắc sáng hơn (Red, Orange, Yellow, Green, Teal, Purple và Pink)
 ### Fixed
 - `.chat-message.highlighted` : Sửa lỗi màu sắc tin nhắn highlighted
+- `.z--btn--fill--secondary-red:hover` : Sửa lỗi màu chữ khi rê chuột vào nút (viền đỏ)
 #### Web specific
 - `.nav__tabs__zalo` (Safari)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## ZaDark v22.9.6
+> Web v6.5
+
+### Fixed
+#### Web specific
+- `.nav__tabs__zalo` (Safari)
+
 ## PC v5.4 && Web v6.4
 ### Changed
 - `scrollbar` : Cập nhật màu nền nhạt hơn cho thanh cuộn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `.card--undo` : Bỏ hiệu ứng mờ cho tin nhắn được thu hồi
 - `:selection` : Cập nhật màu nền khi tô khối chữ
 - `colors` : Thay đổi màu sắc sáng hơn (Red, Orange, Yellow, Green, Teal, Purple và Pink)
+- `.popover-v2, .popover-v3, .zmenu-body.content-only` : Cập nhật hiệu ứng đổ bóng cho Popover, Menu
 ### Fixed
 - `.chat-message.highlighted` : Sửa lỗi màu sắc tin nhắn highlighted
 - `.z--btn--fill--secondary-red:hover` : Sửa lỗi màu chữ khi rê chuột vào nút (viền đỏ)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## ZaDark v22.9.6
-> Web v6.5
+> PC 5.5 && Web v6.5
 
 ### Fixed
+- `.chat-message.highlighted` : Sửa lỗi màu sắc tin nhắn highlighted
 #### Web specific
 - `.nav__tabs__zalo` (Safari)
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -67,88 +67,88 @@
   --SKB100: #3ac8f0;
 
   // Red
-  --R10: #431418;
-  --R20: #431418;
-  --R30: #58181c;
-  --R40: #791a1f;
-  --R50: #a61d24;
-  --R60: #d32029;
-  --R70: #d32029;
-  --R80: #d32029;
-  --R90: #d32029;
-  --R100: #d32029;
+  --R10: #5c0011;
+  --R20: #820014;
+  --R30: #a8071a;
+  --R40: #cf1322;
+  --R50: #f5222d;
+  --R60: #f5222d;
+  --R70: #f5222d;
+  --R80: #f5222d;
+  --R90: #f5222d;
+  --R100: #f5222d;
 
   // Orange
-  --O10: #432716;
-  --O20: #58351c;
-  --O30: #58351c;
-  --O40: #794620;
-  --O50: #a65c26;
-  --O60: #d3722b;
-  --O70: #d3722b;
-  --O80: #d3722b;
-  --O90: #d3722b;
-  --O100: #d3722b;
+  --O10: #612500;
+  --O20: #873800;
+  --O30: #ad4e00;
+  --O40: #d46b08;
+  --O50: #fa8c16;
+  --O60: #fa8c16;
+  --O70: #fa8c16;
+  --O80: #fa8c16;
+  --O90: #fa8c16;
+  --O100: #fa8c16;
 
   // Yellow
-  --Y10: #443b11;
-  --Y20: #595014;
-  --Y30: #7c6e14;
-  --Y40: #aa9514;
-  --Y50: #d8bd14;
-  --Y60: #e8d639;
-  --Y70: #e8d639;
-  --Y80: #e8d639;
-  --Y90: #e8d639;
-  --Y100: #e8d639;
+  --Y10: #614700;
+  --Y20: #876800;
+  --Y30: #ad8b00;
+  --Y40: #d4b106;
+  --Y50: #fadb14;
+  --Y60: #fadb14;
+  --Y70: #fadb14;
+  --Y80: #fadb14;
+  --Y90: #fadb14;
+  --Y100: #fadb14;
 
   // Green
-  --GR10: #1d3712;
-  --GR20: #274916;
-  --GR30: #306317;
-  --GR40: #3c8618;
-  --GR50: #49aa19;
-  --GR60: #49aa19;
-  --GR70: #49aa19;
-  --GR80: #49aa19;
-  --GR90: #49aa19;
-  --GR100: #49aa19;
+  --GR10: #254000;
+  --GR20: #3f6600;
+  --GR30: #5b8c00;
+  --GR40: #7cb305;
+  --GR50: #a0d911;
+  --GR60: #a0d911;
+  --GR70: #a0d911;
+  --GR80: #a0d911;
+  --GR90: #a0d911;
+  --GR100: #a0d911;
 
   // Teal
-  --TL10: #113536;
-  --TL20: #144848;
-  --TL30: #146262;
-  --TL40: #138585;
-  --TL50: #13a8a8;
-  --TL60: #13a8a8;
-  --TL70: #13a8a8;
-  --TL80: #13a8a8;
-  --TL90: #13a8a8;
-  --TL100: #13a8a8;
+  --TL10: #002329;
+  --TL20: #00474f;
+  --TL30: #006d75;
+  --TL40: #08979c;
+  --TL50: #13c2c2;
+  --TL60: #13c2c2;
+  --TL70: #13c2c2;
+  --TL80: #13c2c2;
+  --TL90: #13c2c2;
+  --TL100: #13c2c2;
 
   // Purple
-  --PU10: #24163a;
-  --PU20: #301c4d;
-  --PU30: #3e2069;
-  --PU40: #51258f;
-  --PU50: #642ab5;
-  --PU60: #642ab5;
-  --PU70: #642ab5;
-  --PU80: #642ab5;
-  --PU90: #642ab5;
-  --PU100: #642ab5;
+  --PU10: #120338;
+  --PU20: #22075e;
+  --PU30: #391085;
+  --PU40: #531dab;
+  --PU50: #722ed1;
+  --PU60: #722ed1;
+  --PU70: #722ed1;
+  --PU80: #722ed1;
+  --PU90: #722ed1;
+  --PU100: #722ed1;
 
   // Pink
-  --PI10: #40162f;
-  --PI20: #551c3b;
-  --PI30: #75204f;
-  --PI40: #a02669;
-  --PI50: #cb2b83;
-  --PI60: #cb2b83;
-  --PI70: #cb2b83;
-  --PI80: #cb2b83;
-  --PI90: #cb2b83;
-  --PI100: #cb2b83;
+  --PI10: #520339;
+  --PI20: #780650;
+  --PI30: #9e1068;
+  --PI40: #c41d7f;
+  --PI50: #eb2f96;
+  --PI60: #eb2f96;
+  --PI70: #eb2f96;
+  --PI80: #eb2f96;
+  --PI90: #eb2f96;
+  --PI100: #eb2f96;
 
   // BlackAlpha
   --BA0: transparent;
@@ -267,6 +267,9 @@
 
   --scrollbar-bg: var(--NG40);
   --scrollbar-opacity: 0.5;
+
+  --selection-bg: #0068ff;
+  --selection-color: #fff;
 }
 
 html[data-zadark-theme="dark"] {
@@ -288,7 +291,8 @@ html[data-zadark-theme="dark"] {
   }
 
   ::selection {
-    background: var(--B50) !important;
+    background: var(--selection-bg) !important;
+    color: var(--selection-color) !important;
   }
 
   body.zadark {
@@ -377,6 +381,10 @@ html[data-zadark-theme="dark"] {
       &.--disabled {
         color: var(--R60);
         opacity: 0.5;
+
+        &:hover {
+          color: #fff;
+        }
       }
     }
 
@@ -689,10 +697,8 @@ html[data-zadark-theme="dark"] {
       }
 
       &.card--undo {
-        opacity: 0.75;
-        filter: blur(1px);
         > span {
-          color: var(--primary-text);
+          color: var(--primary-text-50);
         }
       }
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -534,9 +534,10 @@ html[data-zadark-theme="dark"] {
     }
 
     .chat-message.highlighted .card:not(.card--group-photo) {
-      background-color: var(--B10);
+      background: var(--selected-bubble-chat);
+      border-color: var(--selected-bubble-chat-border);
       &:hover {
-        background-color: var(--B20);
+        background: var(--selected-bubble-chat);
       }
     }
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -35,7 +35,7 @@
   --B20: #0e2d5b;
   --B30: #0b3a7e;
   --B40: #074bad;
-  --B50: #035bdc;
+  --B50: #0068ff;
   --B60: #3989ff;
   --B70: #3989ff;
   --B80: #72abff;
@@ -103,16 +103,16 @@
   --Y100: #fadb14;
 
   // Green
-  --GR10: #254000;
-  --GR20: #3f6600;
-  --GR30: #5b8c00;
-  --GR40: #7cb305;
-  --GR50: #a0d911;
-  --GR60: #a0d911;
-  --GR70: #a0d911;
-  --GR80: #a0d911;
-  --GR90: #a0d911;
-  --GR100: #a0d911;
+  --GR10: #063312;
+  --GR20: #0c591e;
+  --GR30: #17802c;
+  --GR40: #26a63b;
+  --GR50: #3acc4d;
+  --GR60: #3acc4d;
+  --GR70: #3acc4d;
+  --GR80: #3acc4d;
+  --GR90: #3acc4d;
+  --GR100: #3acc4d;
 
   // Teal
   --TL10: #002329;
@@ -149,6 +149,18 @@
   --PI80: #eb2f96;
   --PI90: #eb2f96;
   --PI100: #eb2f96;
+
+  // Self Bubble Chat
+  --SBC-10: #080c16;
+  --SBC-20: #1f252f;
+  --SBC-30: #353e4b;
+  --SBC-40: #4b5767;
+  --SBC-50: #617084;
+  --SBC-60: #7b8a9e;
+  --SBC-70: #98a4b4;
+  --SBC-80: #b4beca;
+  --SBC-90: #d0d8e2;
+  --SBC-100: #eaf3fc;
 
   // BlackAlpha
   --BA0: transparent;
@@ -206,22 +218,22 @@
   --input-placeholder-gr: var(--N100);
   --input-icon-gr: var(--N100);
 
-  --self-bubble-chat: #353e4b;
+  --self-bubble-chat: #353e4b; // --SBC-30
   --self-bubble-chat-shadow: transparent;
   --self-link: var(--B60);
 
   --text-quote: var(--primary-text-50);
 
-  --self-quote: #404a59;
-  --self-quote-border: #4b5767;
+  --self-quote: #404a59; // --SBC-40, Alpha 0.5
+  --self-quote-border: #4b5767; // --SBC-40
   --self-quote-line: #4491f6;
 
   --other-bubble-chat: var(--WA100);
   --other-quote: var(--NG10);
   --other-quote-border: var(--NG20);
 
-  --selected-bubble-chat: #1f252f;
-  --selected-bubble-chat-border: #4b5767;
+  --selected-bubble-chat: #1f252f; // --SBC-20
+  --selected-bubble-chat-border: #4b5767; // --SBC-40
 
   --bg-default-csc: var(--NG10);
   --bg-divide-bb-blue: var(--N60);
@@ -245,11 +257,11 @@
 
   --brand-primary: #0068ff;
 
-  --self-bubble-chat-border: #4b5767;
-  --self-bubble-chat-action-bg: #404a58;
-  --self-bubble-chat-action-border: #4b5767;
-  --self-bubble-chat-btn-bg: #4b5767;
-  --self-bubble-chat-btn-border: #617084;
+  --self-bubble-chat-border: #4b5767; // --SBC-40
+  --self-bubble-chat-action-bg: #404a59; // --SBC-40, Alpha 0.5
+  --self-bubble-chat-action-border: #4b5767; // --SBC-40
+  --self-bubble-chat-btn-bg: #4b5767; // --SBC-40
+  --self-bubble-chat-btn-border: #617084; // --SBC-50
 
   --other-bubble-chat-border: var(--NG20);
   --other-bubble-chat-action-bg: var(--NG10);
@@ -263,12 +275,12 @@
   --btn-primary-bg: linear-gradient(45deg, #408dfd, #0068ff);
 
   --file-progress-track: var(--N20);
-  --self-file-progress-track: #4b5767;
+  --self-file-progress-track: #4b5767; // --SBC-40
 
   --scrollbar-bg: var(--NG40);
   --scrollbar-opacity: 0.5;
 
-  --selection-bg: #0068ff;
+  --selection-bg: #0068ff; // --brand-primary
   --selection-color: #fff;
 }
 
@@ -698,6 +710,7 @@ html[data-zadark-theme="dark"] {
 
       &.card--undo {
         > span {
+          font-style: italic;
           color: var(--primary-text-50);
         }
       }
@@ -1378,6 +1391,12 @@ html[data-zadark-theme="dark"] {
       &:before {
         display: none;
       }
+    }
+
+    .popover-v2,
+    .popover-v3,
+    .zmenu-body.content-only {
+      box-shadow: 4px 4px 12px var(--BA50);
     }
   }
 }

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "5.4",
+  "version": "5.5",
   "main": "index.js",
   "repository": "git@github.com:ncdai3651408/za-dark.git",
   "author": "Dai Nguyen <ncdai3651408@gmail.com>",

--- a/src/web/changelog.html
+++ b/src/web/changelog.html
@@ -45,14 +45,7 @@
         </p>
 
         <ul>
-          <li><code>scrollbar</code> : Cập nhật màu nền nhạt hơn cho thanh cuộn</li>
-          <li><code>self-bubble-chat</code> : Cập nhật màu nền tin nhắn của tôi (Màu sắc giống trên Zalo Mobile)</li>
-          <li><code>.z-tooltip</code> : Cập nhật Dark Mode cho Tooltip</li>
-          <li><code>.user-reacted-container</code> : Cập nhật Dark Mode cho "Danh sách bày tỏ cảm xúc"</li>
-          <li><code>.toast-v2</code> : Cập nhật Dark Mode cho Toast v2</li>
-          <li><code>::selection</code> : Cập nhật màu nền khi tô khối chữ</li>
-          <li><code>.zl-avatar__badge</code> : Sửa lỗi màu sắc của biểu tượng "Đang trực tuyến" ở Avatar</li>
-          <li><code>.tab-bar-item</code> : Sửa lỗi Tab Bar Item không nằm giữa ở mục "Thông tin hội thoại"</li>
+          <li>Sửa lỗi màu sắc tin nhắn highlighted</li>
         </ul>
 
         <p>Cảm ơn bạn đã tin tưởng sử dụng ZaDark!</p>

--- a/src/web/changelog.html
+++ b/src/web/changelog.html
@@ -46,6 +46,10 @@
 
         <ul>
           <li>Sửa lỗi màu sắc tin nhắn highlighted</li>
+          <li>Bỏ hiệu ứng mờ cho tin nhắn được thu hồi</li>
+          <li>Cập nhật màu nền khi tô khối chữ</li>
+          <li>Sửa lỗi màu chữ khi rê chuột vào nút (viền đỏ)</li>
+          <li>Thay đổi màu sắc sáng hơn (Red, Orange, Yellow, Green, Teal, Purple và Pink)</li>
         </ul>
 
         <p>Cảm ơn bạn đã tin tưởng sử dụng ZaDark!</p>

--- a/src/web/changelog.html
+++ b/src/web/changelog.html
@@ -50,6 +50,7 @@
           <li>Cập nhật màu nền khi tô khối chữ</li>
           <li>Sửa lỗi màu chữ khi rê chuột vào nút (viền đỏ)</li>
           <li>Thay đổi màu sắc sáng hơn (Red, Orange, Yellow, Green, Teal, Purple và Pink)</li>
+          <li>Cập nhật hiệu ứng đổ bóng cho Popover, Menu</li>
         </ul>
 
         <p>Cảm ơn bạn đã tin tưởng sử dụng ZaDark!</p>

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.4",
+  "version": "6.5",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.4",
+  "version": "6.5",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.4",
+  "version": "6.5",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.4",
+  "version": "6.5",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
+++ b/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1662983195;
+				CURRENT_PROJECT_VERSION = 1663166770;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -502,7 +502,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.4;
+				MARKETING_VERSION = 6.5;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -521,7 +521,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1662983195;
+				CURRENT_PROJECT_VERSION = 1663166770;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.4;
+				MARKETING_VERSION = 6.5;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1662983195;
+				CURRENT_PROJECT_VERSION = 1663166770;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -571,7 +571,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.4;
+				MARKETING_VERSION = 6.5;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -594,7 +594,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1662983195;
+				CURRENT_PROJECT_VERSION = 1663166770;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -609,7 +609,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.4;
+				MARKETING_VERSION = 6.5;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/src/web/vendor/safari/browser.js
+++ b/src/web/vendor/safari/browser.js
@@ -13,7 +13,7 @@
     name: 'Safari',
 
     initClassNames: () => {
-      document.body.classList.add('zadark', 'zadark-browser-ext', 'zadark-safari')
+      document.body.classList.add('zadark', 'zadark-web', 'zadark-safari')
     },
 
     getManifest: () => {

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.4",
+  "version": "6.5",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",


### PR DESCRIPTION
## ZaDark v22.9.6
> PC 5.5 && Web v6.5

### Changed
- `.card--undo` : Bỏ hiệu ứng mờ cho tin nhắn được thu hồi
- `:selection` : Cập nhật màu nền khi tô khối chữ
- `colors` : Thay đổi màu sắc sáng hơn (Red, Orange, Yellow, Green, Teal, Purple và Pink)
- `.popover-v2, .popover-v3, .zmenu-body.content-only` : Cập nhật hiệu ứng đổ bóng cho Popover, Menu
### Fixed
- `.chat-message.highlighted` : Sửa lỗi màu sắc tin nhắn highlighted
- `.z--btn--fill--secondary-red:hover` : Sửa lỗi màu chữ khi rê chuột vào nút (viền đỏ)
#### Web specific
- `.nav__tabs__zalo` (Safari)