### PR TITLE
Feature/v22.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
+## ZaDark v22.9.7
+> PC v5.6 && Web v.6.6
+
+### Fixed
+- `.item-calendar-preview > .date` : Sửa lỗi màu màu sắc của "Ngày" trong Calendar Preview
+
 ## ZaDark v22.9.6
-> PC 5.5 && Web v6.5
+> PC v5.5 && Web v6.5
 
 ### Changed
 - `.card--undo` : Bỏ hiệu ứng mờ cho tin nhắn được thu hồi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 > PC v5.6 && Web v.6.6
 
 ### Fixed
-- `.item-calendar-preview > .date` : Sửa lỗi màu màu sắc của "Ngày" trong Calendar Preview
+- `.item-calendar-preview > .date` : Sửa lỗi màu sắc của "Ngày" trong Calendar Preview
 - `.message-view` : Sửa lỗi Font chữ của nội dung tin nhắn không phải là Font "Open Sans"
+- `.reminder-info-v2 > .wd-time__txt` : Sửa lỗi màu sắc của "Ngày" của Calendar trong Reminder
 
 ## ZaDark v22.9.6
 > PC v5.5 && Web v6.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## ZaDark v22.9.7
+## ZaDark v22.11.1
 > PC v5.6 && Web v.6.6
 
 ### Fixed
 - `.item-calendar-preview > .date` : Sửa lỗi màu màu sắc của "Ngày" trong Calendar Preview
+- `.message-view` : Sửa lỗi Font chữ của nội dung tin nhắn không phải là Font "Open Sans"
 
 ## ZaDark v22.9.6
 > PC v5.5 && Web v6.5

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "22.9.5",
+  "version": "22.11.1",
   "repository": "git@github.com:ncdai3651408/za-dark.git",
   "author": "Dai Nguyen <ncdai3651408@gmail.com>",
   "license": "MIT",

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -1404,6 +1404,10 @@ html[data-zadark-theme="dark"] {
     .v2.view-notice-topic-content .item-calendar-preview > .date {
       color: var(--primary-text);
     }
+
+    .reminder-info-v2 > .content > .cal > .wd-time > .wd-time__txt {
+      color: #fff;
+    }
   }
 }
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -1398,6 +1398,12 @@ html[data-zadark-theme="dark"] {
     .zmenu-body.content-only {
       box-shadow: 4px 4px 12px var(--BA50);
     }
+
+    .group-board-item.v2 .item-calendar-preview > .date,
+    .v2.view-notice-pinmsg-content .item-calendar-preview > .date,
+    .v2.view-notice-topic-content .item-calendar-preview > .date {
+      color: var(--primary-text);
+    }
   }
 }
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -1441,4 +1441,9 @@ body.zadark {
     top: 10px;
     right: 10px;
   }
+
+  .message-view {
+    font-family: "Open Sans", sans-serif;
+    letter-spacing: normal;
+  }
 }

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "5.5",
+  "version": "5.6",
   "main": "index.js",
   "repository": "git@github.com:ncdai3651408/za-dark.git",
   "author": "Dai Nguyen <ncdai3651408@gmail.com>",

--- a/src/web/changelog.html
+++ b/src/web/changelog.html
@@ -45,12 +45,7 @@
         </p>
 
         <ul>
-          <li>Sửa lỗi màu sắc tin nhắn highlighted</li>
-          <li>Bỏ hiệu ứng mờ cho tin nhắn được thu hồi</li>
-          <li>Cập nhật màu nền khi tô khối chữ</li>
-          <li>Sửa lỗi màu chữ khi rê chuột vào nút (viền đỏ)</li>
-          <li>Thay đổi màu sắc sáng hơn (Red, Orange, Yellow, Green, Teal, Purple và Pink)</li>
-          <li>Cập nhật hiệu ứng đổ bóng cho Popover, Menu</li>
+          <li>Sửa lỗi màu màu sắc của "Ngày" trong Calendar Preview</li>
         </ul>
 
         <p>Cảm ơn bạn đã tin tưởng sử dụng ZaDark!</p>

--- a/src/web/changelog.html
+++ b/src/web/changelog.html
@@ -45,7 +45,8 @@
         </p>
 
         <ul>
-          <li>Sửa lỗi màu màu sắc của "Ngày" trong Calendar Preview</li>
+          <li>Sửa lỗi màu sắc của "Ngày" trong Calendar Preview</li>
+          <li>Sửa lỗi Font chữ của nội dung tin nhắn không phải là Font "Open Sans"</li>
         </ul>
 
         <p>Cảm ơn bạn đã tin tưởng sử dụng ZaDark!</p>

--- a/src/web/changelog.html
+++ b/src/web/changelog.html
@@ -47,6 +47,7 @@
         <ul>
           <li>Sửa lỗi màu sắc của "Ngày" trong Calendar Preview</li>
           <li>Sửa lỗi Font chữ của nội dung tin nhắn không phải là Font "Open Sans"</li>
+          <li>Sửa lỗi màu sắc của "Ngày" của Calendar trong Reminder</li>
         </ul>
 
         <p>Cảm ơn bạn đã tin tưởng sử dụng ZaDark!</p>

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.5",
+  "version": "6.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.5",
+  "version": "6.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.5",
+  "version": "6.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.5",
+  "version": "6.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",

--- a/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
+++ b/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1663166770;
+				CURRENT_PROJECT_VERSION = 1663824421;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -502,7 +502,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.5;
+				MARKETING_VERSION = 6.6;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -521,7 +521,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1663166770;
+				CURRENT_PROJECT_VERSION = 1663824421;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -534,7 +534,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.5;
+				MARKETING_VERSION = 6.6;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1663166770;
+				CURRENT_PROJECT_VERSION = 1663824421;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -571,7 +571,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.5;
+				MARKETING_VERSION = 6.6;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -594,7 +594,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1663166770;
+				CURRENT_PROJECT_VERSION = 1663824421;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -609,7 +609,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 6.5;
+				MARKETING_VERSION = 6.6;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "6.5",
+  "version": "6.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "NCDAi Studio",


### PR DESCRIPTION
## ZaDark v22.11.1
> PC v5.6 && Web v.6.6

### Fixed
- `.item-calendar-preview > .date` : Sửa lỗi màu sắc của "Ngày" trong Calendar Preview
- `.message-view` : Sửa lỗi Font chữ của nội dung tin nhắn không phải là Font "Open Sans"
- `.reminder-info-v2 > .wd-time__txt` : Sửa lỗi màu sắc của "Ngày" của Calendar trong Reminder