### PR TITLE
chore: update repository URL to new GitHub location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## ZaDark 26.2
+
+- Sửa lỗi ẩn tin nhắn gần nhất (bao gồm phông chữ) trên Zalo PC `26.3.20`
+- Sửa lỗi Dark Mode: My Documents > Thông tin hội thoại > **Dung lượng lưu trữ**
+
+> Chuyển GitHub Repository từ https://github.com/quaric/zadark sang https://github.com/ncdai/zadark
+
 ## ZaDark 26.1.1
 
 - Cải thiện ZaDark PC: Cho phép xem phiên bản khi chưa cài đặt Zalo PC (`zadark -v` hoặc `zadark --version`)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This document describes the process for running this application on your local c
 
 1. Clone the repo
     ```bash
-    git clone https://github.com/quaric/zadark.git
+    git clone https://github.com/ncdai/zadark.git
     cd zadark
     ```
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ https://zadark.com/awards
 
 ## Star History
 
-[![Star History](https://starchart.cc/quaric/zadark.svg?variant=adaptive)](https://starchart.cc/quaric/zadark)
+[![Star History](https://starchart.cc/ncdai/zadark.svg?variant=adaptive)](https://starchart.cc/ncdai/zadark)
 
 ## Acknowledgments
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "26.1.1",
-  "repository": "https://github.com/quaric/zadark.git",
+  "version": "26.2",
+  "repository": "https://github.com/ncdai/zadark.git",
   "author": {
     "name": "Quaric",
     "email": "hello@quaric.com",

--- a/src/core/scss/_zadark-prv.scss
+++ b/src/core/scss/_zadark-prv.scss
@@ -1,6 +1,8 @@
 @mixin prv-lastest-message {
   .conv-item {
     .conv-item-body__main .conv-message,
+    // * .z-conv-message (Zalo >= v26.3.20)
+    .conv-item-body__main .z-conv-message,
     .conv-unread-react {
       position: relative;
 
@@ -36,6 +38,8 @@
 
     &:hover {
       .conv-item-body__main .conv-message,
+      // * .z-conv-message (Zalo >= v26.3.20)
+      .conv-item-body__main .z-conv-message,
       .conv-unread-react {
         &::after {
           opacity: 0;

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -354,6 +354,7 @@
   --surface-background: var(--NG20);
   --surface-background-subtle: #18191a; // var(--NG15);
   --surface-alt: var(--WA100);
+  --surface-background-overlay: #18191a; // var(--N10);
 
   --layer-background: var(--WA100);
   --layer-background-subtle: #18191a; // var(--N10);
@@ -640,19 +641,31 @@ $FONT_SIZES: (
 );
 
 $LINE_HEIGHTS: (
-  "12": "18px",  // 12 * 1.5
-  "13": "19.5px", // 13 * 1.5
-  "14": "21px",  // 14 * 1.5
-  "15": "22.5px", // 15 * 1.5
-  "16": "24px",  // 16 * 1.5
-  "17": "25.5px", // 17 * 1.5
-  "18": "27px",  // 18 * 1.5
-  "19": "28.5px", // 19 * 1.5
-  "20": "30px",  // 20 * 1.5
-  "21": "31.5px", // 21 * 1.5
-  "22": "33px",  // 22 * 1.5
-  "23": "34.5px", // 23 * 1.5
-  "24": "36px"   // 24 * 1.5
+  "12": "18px",
+  // 12 * 1.5
+  "13": "19.5px",
+  // 13 * 1.5
+  "14": "21px",
+  // 14 * 1.5
+  "15": "22.5px",
+  // 15 * 1.5
+  "16": "24px",
+  // 16 * 1.5
+  "17": "25.5px",
+  // 17 * 1.5
+  "18": "27px",
+  // 18 * 1.5
+  "19": "28.5px",
+  // 19 * 1.5
+  "20": "30px",
+  // 20 * 1.5
+  "21": "31.5px",
+  // 21 * 1.5
+  "22": "33px",
+  // 22 * 1.5
+  "23": "34.5px",
+  // 23 * 1.5
+  "24": "36px" // 24 * 1.5
 );
 
 @mixin zadark-font-sizes() {
@@ -1247,7 +1260,11 @@ html[data-zadark-theme="dark"] {
     .conv-item {
       transition: background-color 100ms ease-in-out;
 
-      .conv-message {
+      .conv-message,
+      // * .z-conv-message (Zalo >= v26.3.20)
+      .z-conv-message {
+        font: 14px / 21px var(--zadark-font-family) !important; // * .z-conv-message style font (Zalo >= v26.3.20)
+
         &.progress-bar {
           .progress-track {
             background-color: var(--NG30) !important;

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "26.1.1",
+  "version": "26.2",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "26.1",
+  "version": "26.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "26.1",
+  "version": "26.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "26.1",
+  "version": "26.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "26.1",
+  "version": "26.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
fix: resolve issue with hiding latest messages in Zalo PC v26.3.20

fix: address Dark Mode issue in My Documents > Thông tin hội thoại > Dung lượng lưu trữ

style: adjust SCSS comments for better readability

docs: update CHANGELOG for version 26.2

build: bump version to 26.2 across package and manifest files